### PR TITLE
feat, refactor: 회원 가입뷰 구현, 컴포넌트 수정, swiftLint 수정

### DIFF
--- a/Projects/App/Scripts/.swiftlint.yml
+++ b/Projects/App/Scripts/.swiftlint.yml
@@ -1,0 +1,129 @@
+disabled_rules: # 사용하지 않는 룰
+    # 배열의 마지막의 comma에 대한 경고
+    - trailing_comma
+    # 라인의 마지막에는 빈 여백이 있으면 안 됨
+    - trailing_whitespace
+
+    # 함수 매개변수들이 여러 개일 경우 세로로 같은 줄에 있어야 함
+    - vertical_parameter_alignment
+
+    # 함수 안은 복잡하면 안 됨 (warning: 10, error: 20)
+    - cyclomatic_complexity
+
+    # 라인 수를 제한함 (warning: 120, error 200)
+    - line_length
+
+    # 함수, 타입, 파일 길이 제한
+    - function_body_length
+    - type_body_length
+
+    # 변수의 이름은 소문자로 시작하며 너무 짧거나 길면 안 됨 (~2: error, ~3: warning, 40~: warning, 60~: error)
+    - identifier_name
+    - type_name
+
+    # 중첩 구문 지양
+    - nesting
+    # todo알람 지우기
+    - todo
+    # 파일 줄번호 제한
+    - file_length
+    # 파라미터 갯수 제한
+    - function_parameter_count
+    # 옵셔널 배열을 제한
+    - discouraged_optional_collection
+#    # 닫는 중괄호 앞에 세로 공백(빈 줄)을 포함하지 마세요.
+#    - vertical_whitespace_closing_braces
+#    # 여는 중괄호 뒤에 세로 공백(빈 줄)을 포함하지 마세요
+#    - vertical_whitespace_opening_braces
+    
+analyzer_rules:
+    # 모든 선언은 한 번 이상 사용되어야 함
+    - unused_declaration
+
+    # 파일을 컴파일하려면 모든 모듈이 필요함
+    - unused_import
+
+opt_in_rules: # 명시적 룰 활성화
+    # 옵셔널 바인딩 강제 언래핑 하지 마세요
+    - force_unwrapping
+    
+    # Boolean 변수는 옵셔널을 사용하지 않도록 권장함
+    - discouraged_optional_boolean
+
+    # type name은 영숫자만 포함, 대문자로 시작해 3-40자 사이어야 함
+    - type_name
+
+    # delegate protocol은 class-only로 참조해 weak로 참조되도록 권장
+    - class_delegate_protocol
+
+    # 닫는 괄호 ')'와 '}' 사이에는 공백이 없어야 함
+    - closing_brace
+
+    # 클로저 내용과 괄호 사이에 공백이 있어야 함
+    - closure_spacing
+
+    # collection elem은 vertically aligned 되어야 함
+    - collection_alignment
+
+    # colon 사용 시 앞 공백 필수, 뒷 공백이 있으면 안 됨
+    - colon
+
+    # comma 사용 시 앞 공백 필수, 뒷 공백이 있으면 안 됨
+    - comma
+
+    # ExpressibleByArrayLiteral를 직접 호출하면 안 됨
+    - compiler_protocol_init
+
+    # first(where:) != nil, firstIndex(where:) != nil 대신 contains 사용을 권장 (https://realm.github.io/SwiftLint/contains_over_first_not_nil.html)
+    - contains_over_first_not_nil
+
+    # filter.count 사용 시 isEmpty 대신 contains 사용 권장 (https://realm.github.io/SwiftLint/contains_over_filter_is_empty.html)
+    - contains_over_filter_is_empty
+
+    # filter.count가 0인지 비교할 때 contains 사용 권장 (https://realm.github.io/SwiftLint/contains_over_filter_count.html)
+    - contains_over_filter_count
+
+    # range(of:) == nil 체크 대신 contains 사용 권장 (https://realm.github.io/SwiftLint/contains_over_range_nil_comparison.html)
+    - contains_over_range_nil_comparison
+
+    # optional collection을 선언하기 보다 empty collection으로 선언 권장discouraged_optional_collection
+    - discouraged_optional_collection
+
+    # if, for, guard, switch, while, catch 사용 시 () 사용 권장하지 않음
+    - control_statement
+
+    # deployment target 보다 낮은 버전의 @available 사용 시 warning
+    - deployment_target
+
+    # 중복 import 방지
+    - duplicate_imports
+
+    # count가 0인지 체크할 때는 isEmpty 사용 권장
+    - empty_count
+
+    # collection, array count 체크 시 isEmpty 사용 권장
+    - empty_collection_literal
+
+    # string empty 체크 시 isEmpty 사용 권장
+    - empty_string
+
+    # 강제 언래핑 사용 금지
+    - force_try
+
+    # array, dict 사용 시 동일한 indent로 표현
+    - literal_expression_end_indentation
+
+    # let, var 선언 시 다른 statments와 한 줄 공백이 필요함
+    - let_var_whitespace
+
+    # 수직 공백 2줄 이상 사용 지양
+    - vertical_whitespace
+
+    # 여는 괄호 앞에서 한 줄 이상의 공백 사용 지양
+    - vertical_whitespace_opening_braces
+
+    # 닫는 괄호 앞에서 한 줄 이상의 공백 사용 지양
+    - vertical_whitespace_closing_braces
+        
+    # delegate는 약한 참조 사용 권장
+    - weak_delegate

--- a/Projects/App/Scripts/SwiftLintRunScript.sh
+++ b/Projects/App/Scripts/SwiftLintRunScript.sh
@@ -1,6 +1,6 @@
 export PATH="$PATH:/opt/homebrew/bin"
 if which swiftlint >/dev/null; then
-    swiftlint
+    swiftlint --config ./Scripts/.swiftlint.yml
 else
     echo "warning: SwiftLint not installed, download form https://github.com/realm/SwiftLint"
 fi

--- a/Projects/App/Sources/Data/Network/NetworkDemo.swift
+++ b/Projects/App/Sources/Data/Network/NetworkDemo.swift
@@ -7,4 +7,3 @@
 //
 
 import SwiftUI
-

--- a/Projects/App/Sources/Data/Repositories/RepoDemo.swift
+++ b/Projects/App/Sources/Data/Repositories/RepoDemo.swift
@@ -7,4 +7,3 @@
 //
 
 import SwiftUI
-

--- a/Projects/App/Sources/DesignSystem/Button/Button.swift
+++ b/Projects/App/Sources/DesignSystem/Button/Button.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-struct DefaultButtonStyle: ButtonStyle {
+struct PinkButtonStyle: ButtonStyle {
     func makeBody(configuration: Self.Configuration) -> some View {
         configuration.label
             .frame(maxWidth: .infinity, maxHeight: 60)

--- a/Projects/App/Sources/DesignSystem/Button/ButtonDemo.swift
+++ b/Projects/App/Sources/DesignSystem/Button/ButtonDemo.swift
@@ -16,7 +16,7 @@ struct ButtonDemo: View {
                 print("DefaultStyle 버튼 눌림")
             }
             /// .buttonStyle에 적용
-            .buttonStyle(DefaultButtonStyle())
+            .buttonStyle(PinkButtonStyle())
             
             Button("Disabled 버튼 테스트용") {
                 print("DisabledStyle 버튼 눌림")
@@ -29,7 +29,7 @@ struct ButtonDemo: View {
                     print("DefaultStyle 버튼 눌림")
                 }
                 /// .buttonStyle에 적용
-                .buttonStyle(DefaultButtonStyle())
+                .buttonStyle(PinkButtonStyle())
                 Button("테스트용") {
                     print("DisabledStyle 버튼 눌림")
                 }

--- a/Projects/App/Sources/DesignSystem/Color/ColorDemo.swift
+++ b/Projects/App/Sources/DesignSystem/Color/ColorDemo.swift
@@ -36,7 +36,6 @@ struct ColorDemo: View {
                     .foregroundColor(Color.symGray4)
                     .frame(width: 50, height: 50)
             }
-
         }
     }
 }

--- a/Projects/App/Sources/DesignSystem/CustomAlert/PopupViewDemo.swift
+++ b/Projects/App/Sources/DesignSystem/CustomAlert/PopupViewDemo.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct PopupDemo: View {
     @State private var isShowingPopup = false
-    @State private var isShowingGuide = false
+    @State private var isShowingGuide = true
     
     var body: some View {
         ZStack {

--- a/Projects/App/Sources/DesignSystem/CustomAlert/PopupViewModifier+Extension.swift
+++ b/Projects/App/Sources/DesignSystem/CustomAlert/PopupViewModifier+Extension.swift
@@ -69,25 +69,29 @@ struct PopupView: ViewModifier {
                     Color.black
                         .opacity(0.3)
                         .ignoresSafeArea()
-                    VStack(alignment: .leading) {
+                    VStack(alignment: .center) {
+                            Image(systemName: "xmark")
+                                .font(PretendardFont.h3Medium)
+                                .padding(.trailing, 10)
+                                .frame(maxWidth: .infinity, alignment: .trailing)
+                        Spacer().frame(height: 10)
                         HStack {
                             Text(title)
                                 .font(PretendardFont.h3Bold)
-                            Spacer()
-                            bottomView
-                                .frame(alignment: .trailing)
+//                            Spacer()
+//                            bottomView
+//                                .frame(alignment: .trailing)
                         }
                         Spacer().frame(height: 20)
                         Text(desc)
                             .font(PretendardFont.bodyMedium)
                             .lineSpacing(1.5)
-                            .multilineTextAlignment(.leading)
-                        
+                            .multilineTextAlignment(.center)
                         Spacer().frame(height: 20)
                     }
                     .padding(.horizontal, 20)
                     .frame(maxWidth: .infinity)
-                    .padding(.top, 40)
+                    .padding(.top, 23)
                     .padding(.bottom, 25)
                     .background(Color.symWhite)
                     .cornerRadius(30)

--- a/Projects/App/Sources/DesignSystem/Form/TextEditor.swift
+++ b/Projects/App/Sources/DesignSystem/Form/TextEditor.swift
@@ -32,7 +32,7 @@ struct CustomTextEditorStyle: ViewModifier {
         } else {
             content
                 .padding(15)
-                .background(Color(UIColor.systemGray5))
+                .background(Color.symGray1)
                 .clipShape(RoundedRectangle(cornerRadius: 30))
                 .scrollContentBackground(.hidden)
         }

--- a/Projects/App/Sources/DesignSystem/Form/TextField.swift
+++ b/Projects/App/Sources/DesignSystem/Form/TextField.swift
@@ -20,20 +20,24 @@ struct CustomTextFieldStyle: ViewModifier {
     func body(content: Content) -> some View {
         switch type {
         case .normal:
-            VStack {
+            VStack(alignment: .leading, spacing: 8) {
                 content
-                    .padding(15)
-                    .padding(.leading, 7)
+                    .padding(.vertical, 20)
+                    .padding(.leading, 30)
                     .background(Color.symGray1)
                     .font(PretendardFont.bodyMedium)
                     .clipShape(RoundedRectangle(cornerRadius: 30))
-                    .padding(.horizontal, 5)
+                Text("한글, 영문을 포함하여 최소 2~5자까지 입력 가능해요. \n닉네임은 가입 후에도 바꿀 수 있어요.")
+                    .font(PretendardFont.bodyMedium)
+                    .foregroundColor(.black)
+                    .lineSpacing(1.5)
+                    .padding(.leading, 15)
             }
         case .error:
             VStack(alignment: .leading, spacing: 8) {
                 content
-                    .padding(15)
-                    .padding(.leading, 7)
+                    .padding(.vertical, 20)
+                    .padding(.leading, 30)
                     .font(PretendardFont.bodyMedium)
                     .background(Color.white)
                     .clipShape(RoundedRectangle(cornerRadius: 30))
@@ -41,12 +45,12 @@ struct CustomTextFieldStyle: ViewModifier {
                         RoundedRectangle(cornerRadius: 30)
                             .stroke(Color.red, lineWidth: 1)
                     )
-                    .padding(.horizontal, 5)
-                Text("사용할 수 없는 닉네임이에요 \n닉네임을 다시 한번 확인해주세요")
-                    .font(PretendardFont.smallMedium)
-                    .foregroundColor(.red)
-                    .lineSpacing(1.5)
-                    .padding(.leading, 15)
+                /// 잠시 레거시..
+//                Text("사용할 수 없는 닉네임이에요 \n닉네임을 다시 한번 확인해주세요")
+//                    .font(PretendardFont.smallMedium)
+//                    .foregroundColor(.red)
+//                    .lineSpacing(1.5)
+//                    .padding(.leading, 15)
             }
         }
     }

--- a/Projects/App/Sources/Presentation/Sign/View/SignDemo.swift
+++ b/Projects/App/Sources/Presentation/Sign/View/SignDemo.swift
@@ -1,9 +1,0 @@
-//
-//  SignDemo.swift
-//  SYM
-//
-//  Created by 박서연 on 2024/01/04.
-//  Copyright © 2023 Mogong. All rights reserved.
-//
-
-// Demo

--- a/Projects/App/Sources/Presentation/Sign/View/SignupNicknameView.swift
+++ b/Projects/App/Sources/Presentation/Sign/View/SignupNicknameView.swift
@@ -1,0 +1,79 @@
+//
+//  SignupNicknameView.swift
+//  SYM
+//
+//  Created by 박서연 on 2024/01/09.
+//  Copyright © 2024 Mogong. All rights reserved.
+//
+
+import SwiftUI
+
+struct SignupNicknameView: View {
+    @State var nickname = ""
+    @State var isPressed: Bool = false
+    
+    var body: some View {
+        VStack {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("환영해요! \n회원님을 어떻게 불러드리면 좋을까요?")
+                    .font(PretendardFont.h4Bold)
+                    .lineSpacing(8)
+
+                VStack(alignment: .leading, spacing: 10) {
+                    TextField("닉네임을 입력해주세요", text: $nickname)
+                        .customTF(type: nickname.count < 5 ? .normal : .error)
+                    getTextField()
+                }
+            }
+            Spacer()
+            getButton()
+            
+        }
+        .padding(24)
+        .navigationTitle("닉네임 설정")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    @ViewBuilder
+    func getButton() -> some View {
+        if 1 <= nickname.count, nickname.count < 6 {
+            Button("완료") {
+                print("완료")
+            }
+            .buttonStyle(PinkButtonStyle())
+        } else {
+            Button("완료") {
+                print("비활성화된 버튼 눌림")
+            }
+            .buttonStyle(DisabledButtonStyle())
+        }
+    }
+    
+    @ViewBuilder
+    func getTextField() -> some View {
+        if nickname.count >= 5 {
+            HStack(alignment: .top) {
+                Text("사용할 수 없는 닉네임이에요 \n닉네임을 다시 한번 확인해주세요")
+                    .font(PretendardFont.smallMedium)
+                    .foregroundColor(.red)
+                    .lineSpacing(1.5)
+                    .padding(.leading, 15)
+                Spacer()
+                HStack(spacing: 0) {
+                    Text("\(nickname.count)")
+                        .font(PretendardFont.smallMedium)
+                        .foregroundColor(Color.symBlack)
+                    Text("/5")
+                        .font(PretendardFont.smallMedium)
+                        .foregroundColor(Color.symGray4)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SignupNicknameView()
+    }
+}

--- a/Projects/App/Sources/Presentation/Sign/View/SignupView.swift
+++ b/Projects/App/Sources/Presentation/Sign/View/SignupView.swift
@@ -1,0 +1,67 @@
+//
+//  SignDemo.swift
+//  SYM
+//
+//  Created by 박서연 on 2024/01/04.
+//  Copyright © 2023 Mogong. All rights reserved.
+//
+import SwiftUI
+
+struct SignupView: View {
+    var body: some View {
+        VStack(spacing: 150) {
+            VStack(spacing: 20) {
+                Circle()
+                    .frame(width: 145, height: 145)
+                
+                VStack(spacing: 1) {
+                    Text("SYM")
+                        .font(PretendardFont.h1Bold)
+                    Text("speak your mind")
+                        .font(PretendardFont.h2Medium)
+                }
+            }
+            
+            VStack(spacing: 30) {
+                HStack(spacing: 35) {
+                    Image(systemName: "star.fill")
+                        .padding(.leading, 35)
+                    Text("카카오톡으로 로그인")
+                        .font(PretendardFont.h4Medium)
+                }.loginCustom(.yellow)
+                
+                HStack(spacing: 35) {
+                    Image(systemName: "heart.fill")
+                        .padding(.leading, 35)
+                    Text("Apple로 로그인")
+                        .font(PretendardFont.h4Medium)
+                        .foregroundColor(.white)
+                }.loginCustom(.symBlack)
+            }
+        }
+        .padding(.horizontal, 24)
+    }
+}
+
+/// background 관련 디자인 빼기
+struct CustomRoundedPaddingModifier: ViewModifier {
+    var color: Color
+    
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 20)
+            .background(color)
+            .clipShape(RoundedRectangle(cornerRadius: 30))
+    }
+}
+
+extension View {
+    func loginCustom(_ color: Color) -> some View {
+        self.modifier(CustomRoundedPaddingModifier(color: color))
+    }
+}
+
+#Preview {
+    SignupView()
+}

--- a/Projects/App/Sources/SYMApp.swift
+++ b/Projects/App/Sources/SYMApp.swift
@@ -1,21 +1,16 @@
 import SwiftUI
 import FirebaseCore
 
-
 class AppDelegate: NSObject, UIApplicationDelegate {
-  func application(_ application: UIApplication,
-                   didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
     FirebaseApp.configure()
-
     return true
   }
 }
 
 @main
 struct SYMApp: App {
-    
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
-    
     var body: some Scene {
         WindowGroup {
             ContentView()


### PR DESCRIPTION
## ✨ feat, refactor: 회원 가입뷰 구현, 컴포넌수 수정, swiftLint 수정 (#12 )
- textfield, textEditor 관련해서 사용에 알맞도록 padding 및 글자 색상 수정이 있습니다.
- popup 뷰 관련하여 디자인 수정된 사항 반영해 놓았습니다.
- @yyomzzi ButtonStyle중에 Default가 기존 Default랑 겹쳐서 혼동이 생겨 PinkButtonStyle로 이름 수정하였습니다.
- 회원가입 화면 뷰 1차 구현하였습니다. (지수님과의 추후 회의 후 수정이 필요할 것 같습니다.)
- 각박한.. 린트의 규칙 속에서 trailing_whitespace의 규칙 제한을 없앴습니다. (각 Scripts/.swiftlit.yml 파일에서 제한 풀린 규칙 확인 가능)
  
## 🙋🏻 PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

  
## 📷 Key Changes
<img width="531" alt="Pasted Graphic 6" src="https://github.com/Good-MoGong/SYM/assets/110394722/ce5fb67f-f9e0-43a7-8cac-f56610a5737f">
<br>
이름 수정 되었습니다.
<br>

<img width="487" alt="Pasted Graphic 8" src="https://github.com/Good-MoGong/SYM/assets/110394722/61dd12dd-5ca9-46f5-9be7-6b6d164f2060">
<img width="449" alt="Pasted Graphic 7" src="https://github.com/Good-MoGong/SYM/assets/110394722/c6b9bcfb-2493-420c-8966-8b936ceb3a3b">
<br>
팝업뷰 디자인 수정사항 입니다.
<br>

<img width="311" alt="Pasted Graphic 10" src="https://github.com/Good-MoGong/SYM/assets/110394722/6602107d-0634-4eac-b83d-3561e9a56dac">
<img width="311" alt="Pasted Graphic 11" src="https://github.com/Good-MoGong/SYM/assets/110394722/05673d9e-fd25-4305-97c4-0ae003e51adf">
<br> 
회원가입 뷰 구현 화면입니다.
<br>
  
## ✍🏻 To Reviewers
- 로고는 추후에 수정이 필요합니다.
- 카카오톡 로그인 관련하여 색상 값 수정이 필요합니다.
- 지수님과 textfield 관련하여 추후 5/5 부분에 대한 협의가 필요합니다 ㅠㅠ (몇글자부터 글자수 노티줄 것인지에 대한 부분)