### PR TITLE
feat, fix: BackgroundColor, CommonDemo 수정, 기록 보기 뷰 구현

### DIFF
--- a/Projects/App/Sources/DesignSystem/Common/BackgroundColor.swift
+++ b/Projects/App/Sources/DesignSystem/Common/BackgroundColor.swift
@@ -11,6 +11,9 @@ import SwiftUI
 public enum BackgroundType {
     case subColor
     case whiteWithStroke
+    case brightWithStroke
+    case sentenceField
+    case settenceTitle
 //    case subColorTextEditor
 }
 
@@ -20,19 +23,50 @@ struct BackgroundView: ViewModifier {
         switch type {
         case .subColor:
             content
-                .padding(.horizontal, 20)
+                .padding(.horizontal, 30)
                 .padding(.vertical, 12)
                 .background(Color.sub)
                 .foregroundColor(.white)
                 .clipShape(RoundedRectangle(cornerRadius: 30))
         case .whiteWithStroke:
             content
-                .padding(.horizontal, 20)
+                .padding(.horizontal, 30)
                 .padding(.vertical, 12)
                 .background(
                     RoundedRectangle(cornerRadius: 30)
                         .stroke(Color.symGray2, lineWidth: 2)
                 )
+        case .brightWithStroke:
+            content
+                .frame(width: 99, height: 41) // subColor, WhiteWithStroke는 padding 값만 넣어서 글자 수에 따라서 크기가 변하지만,
+                                              // 여기에만 frame 값을 넣어서 글자 수에 상관 없이 고정되게 해보았습니다.
+                .background(Color.bright)
+                .cornerRadius(30)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 30)
+                        .stroke(Color.sub, lineWidth: 1)
+                )
+        case .sentenceField:
+            content
+                .font(PretendardFont.bodyMedium)
+                .lineSpacing(7) // 피그마에는 4로 되어있는데 너무 좁아보여서 일단 7로 설정함
+                .padding(.horizontal, 17)
+                .padding(.vertical, 23)
+                .frame(width: .infinity, height: 214)
+                .background(Color.bright)
+                .clipShape(RoundedRectangle(cornerRadius: 20))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(Color.sub, lineWidth: 1)
+                        .frame(width: .infinity, height: 214)
+                )
+        case .settenceTitle:
+            content
+                .frame(width: 132, height: 37)
+                .font(PretendardFont.h4Bold)
+                .background(Color.sub)
+                .foregroundColor(.white)
+                .clipShape(RoundedRectangle(cornerRadius: 30))
 //        case .subColorTextEditor:
 //            content
 //                .padding(.horizontal, 17)

--- a/Projects/App/Sources/DesignSystem/Common/CommonDemo.swift
+++ b/Projects/App/Sources/DesignSystem/Common/CommonDemo.swift
@@ -11,10 +11,24 @@ import SwiftUI
 struct CommonDemo: View {
     var body: some View {
         VStack {
-            Text("매우 기쁜")
+            Text("즐거운")
                 .setTextBackground(.subColor)
             Text("매우 기쁜")
                 .setTextBackground(.whiteWithStroke)
+            Text("만족스러운")
+                .setTextBackground(.brightWithStroke)
+            ZStack {
+                Text("""
+                푸른하늘처럼 투명하게 새벽공기처럼 청아하게 언제나 파란 희망으로 다가서는 너에게 나는 그런 사람이고 싶다. 들판에 핀 작은 풀꽃같이 바람에 날리는 어여쁜 민들레같이 잔잔한 미소와 작은 행복을 주는 사람 너에게 나는 그런 사람이고 싶다. 따스한 햇살이 되어시린 가슴으로 아파할 때 포근하게 감싸주며 위로가 되는 사람 너에게 나는 그런 사람이고 싶다. 긴 인생이
+                """)
+                .setTextBackground(.sentenceField)
+                .padding(.horizontal, 20)
+                
+                Text("사건")
+                    .setTextBackground(.settenceTitle)
+                    .padding(.trailing, 170)
+                    .padding(.bottom, 215)
+            }
         }
     }
 }

--- a/Projects/App/Sources/Presentation/Calendar/RecordOrganizeView.swift
+++ b/Projects/App/Sources/Presentation/Calendar/RecordOrganizeView.swift
@@ -1,0 +1,95 @@
+//
+//  RecordOrganizeView.swift
+//  SYM
+//
+//  Created by 전민돌 on 1/27/24.
+//  Copyright © 2024 Mogong. All rights reserved.
+//
+
+import SwiftUI
+
+struct RecordOrganizeView: View {
+    var body: some View {
+        NavigationStack {
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading) {
+                    Spacer(minLength: 33)
+                    
+                    Text("나의 감정")
+                        .font(PretendardFont.h4Bold)
+                        .padding(.leading, 20)
+                        .padding(.bottom, -10)
+                    
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack {
+                            ForEach(0..<5) { index in
+                                Text("만족스러운") // 추후에 실제 감정 결과로 변경 필요
+                                    .setTextBackground(.brightWithStroke)
+                                    .padding(.horizontal, 2)
+                            }
+                        }
+                        .padding(.leading, 2)
+                        .padding()
+                    }
+                    .padding(.bottom, 5)
+                    
+                    Text("나의 기록")
+                        .font(PretendardFont.h4Bold)
+                        .padding(.leading, 20)
+                        .padding(.bottom, 7)
+                    
+                    ZStack {
+                        Text("""
+                        푸른하늘처럼 투명하게 새벽공기처럼 청아하게 언제나 파란 희망으로 다가서는 너에게 나는 그런 사람이고 싶다. 들판에 핀 작은 풀꽃같이 바람에 날리는 어여쁜 민들레같이 잔잔한 미소와 작은 행복을 주는 사람 너에게 나는 그런 사람이고 싶다. 따스한 햇살이 되어시린 가슴으로 아파할 때 포근하게 감싸주며 위로가 되는 사람 너에게 나는 그런 사람이고 싶다. 긴 인생이
+                        """) // 추후에 실제 기록으로 변경 필요
+                        .setTextBackground(.sentenceField)
+                        
+                        Text("사건")
+                            .setTextBackground(.settenceTitle)
+                            .padding(.trailing, 180)
+                            .padding(.bottom, 215)
+                    }
+                    .padding(.horizontal, 20)
+                    
+                    ZStack {
+                        Text("""
+                        푸른하늘처럼 투명하게 새벽공기처럼 청아하게 언제나 파란 희망으로 다가서는 너에게 나는 그런 사람이고 싶다. 들판에 핀 작은 풀꽃같이 바람에 날리는 어여쁜 민들레같이 잔잔한 미소와 작은 행복을 주는 사람 너에게 나는 그런 사람이고 싶다. 따스한 햇살이 되어시린 가슴으로 아파할 때 포근하게 감싸주며 위로가 되는 사람 너에게 나는 그런 사람이고 싶다. 긴 인생이
+                        """) // 추후에 실제 기록으로 변경 필요
+                        .setTextBackground(.sentenceField)
+                        
+                        Text("생각")
+                            .setTextBackground(.settenceTitle)
+                            .padding(.trailing, 180)
+                            .padding(.bottom, 215)
+                    }
+                    .padding(.horizontal, 20)
+                    
+                    ZStack {
+                        Text("""
+                        푸른하늘처럼 투명하게 새벽공기처럼 청아하게 언제나 파란 희망으로 다가서는 너에게 나는 그런 사람이고 싶다. 들판에 핀 작은 풀꽃같이 바람에 날리는 어여쁜 민들레같이 잔잔한 미소와 작은 행복을 주는 사람 너에게 나는 그런 사람이고 싶다. 따스한 햇살이 되어시린 가슴으로 아파할 때 포근하게 감싸주며 위로가 되는 사람 너에게 나는 그런 사람이고 싶다. 긴 인생이
+                        """) // 추후에 실제 기록으로 변경 필요
+                        .setTextBackground(.sentenceField)
+                        
+                        Text("행동")
+                            .setTextBackground(.settenceTitle)
+                            .padding(.trailing, 180)
+                            .padding(.bottom, 215)
+                    }
+                    .padding(.horizontal, 20)
+                    
+                    Button("완료") {
+                        print("완료 버튼") // 추후에 action 추가 필요
+                    }
+                    .buttonStyle(MainButtonStyle(isButtonEnabled: true))
+                    .padding(.horizontal, 20)
+                }
+            }
+            .navigationTitle("2023. 1. 28 일기") // 추후에 실제로 실제 날짜로 변경 필요
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+#Preview {
+    RecordOrganizeView()
+}


### PR DESCRIPTION
## ✨ feat, fix: BackgroundColor, CommonDemo 수정, 기록 보기 뷰 구현 (#43)
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 감정 기록을 끝내거나 캘린더에서 특정 날짜를 선택하면 이동하는 기록 보기 뷰를 구현해 보았습니다.
- 기록 보기 뷰에 필요한 컴포넌트들을 BackgroundColor 파일에 추가 및 수정했습니다.
- 새로 추가한 컴포넌트들을 CommonDemo 에 추가했습니다.
- 컴포넌트를 추가할 때 기존에 있던 컴포넌트들은 padding 값만 있어서 글자 수에 따라 크기가 변하는 것을 막기 위해서 frame 값을 추가해서 크기를 고정시켜 보았습니다.
<!---- Resolves: #(Isuue Number) 이슈 넘버링 해주세요! -->
  
## 🙋🏻 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

  
## 📷 Key Changes
<!---- 구현 내용 중 애니메이션이나 화면 UI와 관련된 내용이 있을때 넣을 수 있다면 넣어주세요. -->

https://github.com/Good-MoGong/SYM/assets/66257281/4a0c39ca-4492-495c-87a7-f7baea432555
  
## ✍🏻 To Reviewers
<!---- 팀원들에게 코드리뷰를 할 때 확인해주었으면 하는 내용을 적어주세요. -->
- 기록 보기 뷰에서 추후에 데이터를 가져와야 하는 부분에는 주석을 달아 놓았습니다.
- 그 외에 추가한 주석들도 확인해 주시면 감사하겠습니다..!