### PR TITLE
Feat: 카카오톡 로그인 탈퇴 구현 완료

### DIFF
--- a/Projects/App/Sources/Domain/UseCases/Protocol/Services/AuthenticationService.swift
+++ b/Projects/App/Sources/Domain/UseCases/Protocol/Services/AuthenticationService.swift
@@ -33,6 +33,12 @@ protocol AuthenticationServiceType {
     func logout() -> AnyPublisher<Void, ServiceError>
     func logoutWithKakao()
     func checkUserNickname(userID: String, completion: @escaping (Bool) -> Void)
+    
+    // MARK: - 카카오톡 탈퇴 구현하기
+    func unlinkKakao()
+    
+    // 파베에서 유저 삭제
+    func deleteFirebaseAuth()
 }
 
 class AuthenticationService: AuthenticationServiceType {
@@ -117,6 +123,34 @@ class AuthenticationService: AuthenticationServiceType {
                     completion(false) // Call completion with false if documents are nil
                 }
             }
+        }
+    }
+    
+    
+    // MARK: - 카카오톡 탈퇴
+    /// 카카오톡 탈퇴
+    func unlinkKakao() {
+        UserApi.shared.unlink { error in
+            if let error = error {
+                print("🟨 Auth DEBUG: 카카오톡 탈퇴 중 에러 발생 \(error.localizedDescription)")
+            } else {
+                print("🟨 Auth DEBUG: 카카오톡 탈퇴 성공")
+            }
+        }
+    }
+    
+    /// 파베의 auth에서 유저 정보 삭제
+    func deleteFirebaseAuth() {
+        if let user = Auth.auth().currentUser {
+            user.delete { error in
+                if let error = error {
+                    print("🔥 Firebase DEBUG: firebase auth에서 회원 삭제 중 에러 발생 \(error.localizedDescription)")
+                } else {
+                    print("🔥 Firebase DEBUG: firebase auth에서 회원 삭제 성공")
+                }
+            }
+        } else {
+            print("🔥 Firebase DEBUG: firebase auth에 회원정보가 존재하지 않습니다.")
         }
     }
 }
@@ -296,4 +330,8 @@ class StubAuthenticationService: AuthenticationServiceType {
     func logoutWithKakao() { }
     
     func checkUserNickname(userID: String, completion: @escaping (Bool) -> Void) { }
+    
+    func unlinkKakao() { }
+    
+    func deleteFirebaseAuth() { }
 }

--- a/Projects/App/Sources/Domain/UseCases/Protocol/Services/FirebaseService.swift
+++ b/Projects/App/Sources/Domain/UseCases/Protocol/Services/FirebaseService.swift
@@ -27,4 +27,7 @@ final class FirebaseService {
             print("\(error.localizedDescription)")
         }
     }
+    
+    // 탈퇴시 삭제되는 유저 정보를 찾는 함수
+    
 }

--- a/Projects/App/Sources/Domain/UseCases/Protocol/Services/FirebaseService.swift
+++ b/Projects/App/Sources/Domain/UseCases/Protocol/Services/FirebaseService.swift
@@ -24,10 +24,19 @@ final class FirebaseService {
         do {
             try documentRef.setData(from: user)
         } catch let error{
-            print("\(error.localizedDescription)")
+            print("🔥 Firebase DEBUG: Firestore의 User DB에 유저 추가시 에러 발생 \(error.localizedDescription)")
         }
     }
     
-    // 탈퇴시 삭제되는 유저 정보를 찾는 함수
-    
+    // 탈퇴시 삭제되는 유저 정보를 찾는 함수 일단 User 디비만 삭제
+    // (만약 일기 데이터로 인하여 하위 컬렉션 생성시.. 하위 컬렉션은 삭제되지 않음(파베에서 제공x)
+    func deleteUserData(user: String) {
+        let documentRef = db.collection("User").document(user).delete() { error in
+            if let error = error {
+                print("🔥 Firebase DEBUG: User의 Firestore 문서 삭제 중 에러 발생 \(error.localizedDescription)")
+            } else {
+                print("🔥 Firebase DEBUG: User의 Firestore 문서 삭제 완료")
+            }
+        }
+    }
 }

--- a/Projects/App/Sources/Presentation/Authencation/AuthenticatedViewModel.swift
+++ b/Projects/App/Sources/Presentation/Authencation/AuthenticatedViewModel.swift
@@ -25,6 +25,9 @@ class AuthenticationViewModel: ObservableObject {
         case appleLoginCompletion(Result<ASAuthorization, Error>) // 인증이 된 후
         case kakaoLogin
         case logout
+        
+        // MARK: - 카카오 탈퇴
+        case unlinkKakao
     }
     
     @Published var isLoading = false
@@ -117,6 +120,12 @@ class AuthenticationViewModel: ObservableObject {
                     self?.userId = nil
                 }.store(in: &subscritpions)
             self.authenticationState = .initial
+            
+        case .unlinkKakao:
+            container.services.authService.unlinkKakao()
+            container.services.authService.deleteFirebaseAuth()
+            self.authenticationState = .initial
+
         }
     }
 }

--- a/Projects/App/Sources/Presentation/MyPage/SettingView.swift
+++ b/Projects/App/Sources/Presentation/MyPage/SettingView.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 
 struct SettingView: View {
+    private let firebaseService = FirebaseService.shared
+    
     @State private var isShowingLogoutPopup = false
     @State private var isShowingWithdrawalPopup = false
     @EnvironmentObject var authViewModel: AuthenticationViewModel
@@ -55,11 +57,18 @@ struct SettingView: View {
         })
         .popup(isShowing: $isShowingWithdrawalPopup,
                type: .doubleButton(leftTitle: "확인", rightTitle: "취소"),
-               title: "로그아웃 하시겠어요?",
+               title: "탈퇴하시겠어요?",
                boldDesc: "탈퇴 전 유의 사항",
                desc: "• 탈퇴 후 7일간은 재가입이 불가합니다. \n• 탈퇴 시 계정의 모든 정보는 삭제되며, \n   재가입후에도 복구 되지 않습니다.",
                confirmHandler: {
             print("탈퇴하기")
+            
+            guard let userId = authViewModel.userId else {
+                return
+                print("회원가입 정보 없음!!!!!! 탈퇴에러 발생!!!!!!")
+            }
+            
+            firebaseService.deleteUserData(user: userId)
             authViewModel.send(action: .unlinkKakao)
             self.isShowingWithdrawalPopup.toggle()
         },
@@ -67,6 +76,7 @@ struct SettingView: View {
             print("취소 버튼")
             self.isShowingWithdrawalPopup.toggle()
         })
+        
         .popup(isShowing: $isShowingLogoutPopup,
                type: .doubleButton(leftTitle: "확인", rightTitle: "취소"),
                title: "로그아웃 하시겠어요?",

--- a/Projects/App/Sources/Presentation/MyPage/SettingView.swift
+++ b/Projects/App/Sources/Presentation/MyPage/SettingView.swift
@@ -59,7 +59,8 @@ struct SettingView: View {
                boldDesc: "탈퇴 전 유의 사항",
                desc: "• 탈퇴 후 7일간은 재가입이 불가합니다. \n• 탈퇴 시 계정의 모든 정보는 삭제되며, \n   재가입후에도 복구 되지 않습니다.",
                confirmHandler: {
-            print("확인")
+            print("탈퇴하기")
+            authViewModel.send(action: .unlinkKakao)
             self.isShowingWithdrawalPopup.toggle()
         },
                cancelHandler: {

--- a/Projects/App/Sources/Presentation/MyPage/SettingView.swift
+++ b/Projects/App/Sources/Presentation/MyPage/SettingView.swift
@@ -62,9 +62,15 @@ struct SettingView: View {
                desc: "• 탈퇴 후 7일간은 재가입이 불가합니다. \n• 탈퇴 시 계정의 모든 정보는 삭제되며, \n   재가입후에도 복구 되지 않습니다.",
                confirmHandler: {
             print("탈퇴하기")
-            firebaseService.deleteUserData(user: userId)
-            authViewModel.send(action: .unlinkKakao)
-            self.isShowingWithdrawalPopup.toggle()
+            
+            if let userId = authViewModel.userId {
+                firebaseService.deleteUserData(user: userId)
+                authViewModel.send(action: .unlinkKakao)
+                self.isShowingWithdrawalPopup.toggle()
+            } else {
+                print("🔥 Firebase DEBUG: 회원가입 정보 없음, 유저 정보 삭제 시 에러 발생")
+            }
+            
         },
                cancelHandler: {
             print("취소 버튼")

--- a/Projects/App/Sources/Presentation/MyPage/SettingView.swift
+++ b/Projects/App/Sources/Presentation/MyPage/SettingView.swift
@@ -62,12 +62,6 @@ struct SettingView: View {
                desc: "• 탈퇴 후 7일간은 재가입이 불가합니다. \n• 탈퇴 시 계정의 모든 정보는 삭제되며, \n   재가입후에도 복구 되지 않습니다.",
                confirmHandler: {
             print("탈퇴하기")
-            
-            guard let userId = authViewModel.userId else {
-                return
-                print("회원가입 정보 없음!!!!!! 탈퇴에러 발생!!!!!!")
-            }
-            
             firebaseService.deleteUserData(user: userId)
             authViewModel.send(action: .unlinkKakao)
             self.isShowingWithdrawalPopup.toggle()

--- a/Projects/App/Sources/Presentation/Record/Views/RecordDemo.swift
+++ b/Projects/App/Sources/Presentation/Record/Views/RecordDemo.swift
@@ -21,7 +21,7 @@ struct RecordDemo: View {
                 }
             }
             .navigationDestination(isPresented: $isShowingRecordView) {
-                RecordStartView(isShowingRecordView: $isShowingRecordView)
+//                RecordStartView(isShowingRecordView: $isShowingRecordView)
             }
         }
     }


### PR DESCRIPTION
## ✨ Feat: 카카오톡 로그인 탈퇴 구현 완료 #94 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) 이슈 넘버링 해주세요! -->
  
## 🙋🏻 PR 유형
어떤 변경 사항이 있나요?
- 카카오톡 탈퇴 구현 완료했습니다. 
- 탈퇴 시 유저의 카톡 연결된 서비스에서 SYM 삭제까지 연결해 놓았으며,
- Firebase Auth, FirebaseStore에서도 모두 삭제됩니다.

<br>

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

  
## 📷 Key Changes
<!---- 구현 내용 중 애니메이션이나 화면 UI와 관련된 내용이 있을때 넣을 수 있다면 넣어주세요. -->

  
## ✍🏻 To Reviewers
<!---- 팀원들에게 코드리뷰를 할 때 확인해주었으면 하는 내용을 적어주세요. -->
@OzDevelop 탈퇴 할 때 팝업에 애니메이션 마이페이지에서 한번만 더 적용시켜주실 수 있으실까요? .animation(value, body)로 해주시면 될것 같습니다.  
@LutherCho Firebase에서 유저에 해당하는 Firestore데이터 삭제시 문서 번호(유저id)로 지우고 있습니다. 이때 문서의 하위 컬렉션에 대한 삭제는 파베에서 지원해주고 있지 않아서.. 이 부분에 있어서 일기 데이터 firestore에 올릴 때 어떻게 가져가고 있는지에 대해서 회의가 필요할거 같습니다.. ㅠㅠ 🥹

<img width="922" alt="image" src="https://github.com/Good-MoGong/SYM/assets/110394722/34fc4a93-e753-441f-95ae-0fb0113e2ef5">

<br>

<img width="922" alt="image" src="https://github.com/Good-MoGong/SYM/assets/110394722/9ef48e23-1c5c-407f-bafb-84a2486ac8c8">

<br>

https://firebase.google.com/docs/firestore/manage-data/delete-data?hl=ko&_gl=1*h4e9q4*_up*MQ..*_ga*MTUyNjEyOTU2LjE3MDg4ODc1MzY.*_ga_CW55HF8NVT*MTcwODg4NzUzNi4xLjAuMTcwODg4NzUzNi4wLjAuMA..
