### PR TITLE
Fix: calendarRecordView의 기록보러가기 버튼에서 데이터 fetch

### DIFF
--- a/Projects/App/Sources/Presentation/Calendar/View/CalendarDetailView.swift
+++ b/Projects/App/Sources/Presentation/Calendar/View/CalendarDetailView.swift
@@ -276,10 +276,6 @@ struct DateButton: View {
         VStack {
             Button {
                 selectDate = value.date
-                if calendarViewModel.diaryExists(on: value.date.formatToString()) {
-                    calendarViewModel.recordDiary.date = selectDate.formatToString()
-                    calendarViewModel.recordSpecificFetch()
-                }
             } label: {
                 VStack(spacing: 3) {
                     Text(isToday ? "오늘" : "")

--- a/Projects/App/Sources/Presentation/Calendar/View/CalendarMainView.swift
+++ b/Projects/App/Sources/Presentation/Calendar/View/CalendarMainView.swift
@@ -52,8 +52,6 @@ struct CalendarMainView: View {
                 .padding(.bottom, 20)
                 .scrollIndicators(.hidden)
                 .onAppear {
-                    // 오늘날짜 페치해서 RecordView 어떻게 나타낼지
-                    calendarViewModel.todayrecordFetch()
                     // 데이터 전체 페치
                     calendarViewModel.recordWholeFetch()
                     calendarViewModel.userID = authViewModel.userId ?? ""

--- a/Projects/App/Sources/Presentation/Calendar/View/CalendarRecordView.swift
+++ b/Projects/App/Sources/Presentation/Calendar/View/CalendarRecordView.swift
@@ -65,6 +65,8 @@ struct CalendarRecordView: View {
                 if existRecord == true {
                     // 기록이 있을 경우
                     Button {
+                        calendarViewModel.recordDiary.date = selectDate.formatToString()
+                        calendarViewModel.recordSpecificFetch()
                         isShowingOrganizeView = true
                     } label: {
                         Text("기록 보러가기")

--- a/Projects/App/Sources/Presentation/Calendar/ViewModel/CalendarViewModel.swift
+++ b/Projects/App/Sources/Presentation/Calendar/ViewModel/CalendarViewModel.swift
@@ -45,17 +45,6 @@ final class CalendarViewModel: RecordConditionFetch {
         }
     }
     
-    ///  오늘 날짜 기록 불러오기
-    func todayrecordFetch() {
-        calendarUseCase.fetchRecord(date: Date().formatToString()) { diary, isSuccess in
-            DispatchQueue.main.async {
-                self.recordDiary = diary
-                // RecordView의 beforeRecord랑 반대로 동작해서 반대로 값 넣어줘야함
-                self.completeRecord = isSuccess
-            }
-        }
-    }
-    
     /// 전체 기록 불러오기
     func recordWholeFetch() {
         calendarUseCase.fetchWholeRecord { diaryArray in


### PR DESCRIPTION
## ✨ Fix: calendarRecordView의 기록보러가기 버튼에서 데이터 fetch (#138 )
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) 이슈 넘버링 해주세요! -->
- 이전에 캘린더에서 기록을 본 후에 다시 mainCalendarView로 돌아와서 다시 기록보기 버튼을 누르면 데이터 fetch가 되지 않는 현상이 있었습니다
  - 이전에 기록을 보여줄 때는 기록을 확인하려는 `날짜`를 누르면 바로 데이터 fetch 후에 RecordOrganizeView로 이동하는 흐름이였습니다. 그래서 날짜를 누를때만 데이터가 fetch 되었습니다. 
  - 현재는 날짜를 선택한 후에 `기록 보러가기` 버튼을 눌러야 기록을 볼 수 있는 흐름이기 때문에 날짜를 탭할때가 아닌 기록 보러가기 버튼을 탭할때 해당 날짜의 데이터를 fetch 하는 것으로 바꾸었습니다.
- 더불어, CalendarRecordView(캘린더 하단의 기록 확인뷰)가 이전에는 "오늘" 의 기록만 보여주는 것이어서 오늘 날짜의 기록만을 fetch 하는 함수가 따로 필요했었는데, 현재는 모든 날짜의 기록 유무를 보여주기 때문에 오늘 날짜 기록 페치를 따로 구현할 필요가 없어서 함수 삭제했습니다.
  
## 🙋🏻 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

  
## 📷 Key Changes
<!---- 구현 내용 중 애니메이션이나 화면 UI와 관련된 내용이 있을때 넣을 수 있다면 넣어주세요. -->

https://github.com/Good-MoGong/SYM/assets/133854561/ad390937-4b0e-492f-a6a7-c5947402e427


  
## ✍🏻 To Reviewers
<!---- 팀원들에게 코드리뷰를 할 때 확인해주었으면 하는 내용을 적어주세요. -->
