### PR TITLE
Refact: CalendarMainView에서 .onAppear로 기록 전체 fetch 하는 함수 수정

### DIFF
--- a/Projects/App/Sources/Presentation/Calendar/View/CalendarMainView.swift
+++ b/Projects/App/Sources/Presentation/Calendar/View/CalendarMainView.swift
@@ -52,8 +52,7 @@ struct CalendarMainView: View {
                 .padding(.bottom, 20)
                 .scrollIndicators(.hidden)
                 .onAppear {
-                    // 데이터 전체 페치
-                    calendarViewModel.recordWholeFetch()
+                    calendarViewModel.observeCoreData()
                     calendarViewModel.userID = authViewModel.userId ?? ""
                 }
                 .animation(.easeIn, value: currentDate)

--- a/Projects/App/Sources/Presentation/Calendar/ViewModel/CalendarViewModel.swift
+++ b/Projects/App/Sources/Presentation/Calendar/ViewModel/CalendarViewModel.swift
@@ -32,7 +32,7 @@ final class CalendarViewModel: RecordConditionFetch {
         recordWholeFetch()
     }
     
-    /// NSMagagedObjectContext가
+    /// NSMagagedObjectContext가 저장이 완료될 때마다 전체 페치 시행하는 함수
     func observeCoreData() {
         NotificationCenter.default.publisher(for: NSManagedObjectContext.didSaveObjectsNotification)
             .receive(on: DispatchQueue.main)

--- a/Projects/App/Sources/Presentation/Calendar/ViewModel/CalendarViewModel.swift
+++ b/Projects/App/Sources/Presentation/Calendar/ViewModel/CalendarViewModel.swift
@@ -7,10 +7,15 @@
 //
 
 import Foundation
+import CoreData
+import Combine
 
 final class CalendarViewModel: RecordConditionFetch {
-    private let calendarUseCase: CalendarUseCase
+    
     var userID: String = ""
+    
+    private let calendarUseCase: CalendarUseCase
+    private var cancellables = Set<AnyCancellable>()
     
     // 서연 추가
     @Published var impossibleMessage: Toast?
@@ -24,6 +29,17 @@ final class CalendarViewModel: RecordConditionFetch {
     
     init(calendarUseCase: CalendarUseCase) {
         self.calendarUseCase = calendarUseCase
+        recordWholeFetch()
+    }
+    
+    /// NSMagagedObjectContext가
+    func observeCoreData() {
+        NotificationCenter.default.publisher(for: NSManagedObjectContext.didSaveObjectsNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { _ in
+                self.recordWholeFetch()
+            }
+            .store(in: &cancellables)
     }
     
     // 서연 추가


### PR DESCRIPTION
## ✨ Refact: CalendarMainView에서 .onAppear로 기록 전체 fetch 하는 함수 수정 (#141)
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) 이슈 넘버링 해주세요! -->
- 현재 `CalendarMainView`에서 전체 기록 fetch 함수가  해당 view가 `onAppear` 될 때 마다 호출되고 있습니다. 하지만 CalendarMainView는 우리 앱의 가장 메인이 되는 view이고 기록 하기 전/후, 기록 보기 전/후에 계속 onAppear되기 때문에 어떤 변화가 없어도 계속 fetch가 되는 것이 좋은 방법이 아니라고 생각했습니다.
  - 그래서 기록을 하거나 수정하게 되면 `coreData`에 다시 저장이 되기 때문에 coreData에 변화가 있을 때 마다 기록을 fetch 하는 것이 더 좋은 방법이라고 생각했습니다.
  - `CalendarViewModel`에 `observeCoreData`라는 함수를 생성했습니다. 이 함수는 `NotificationCenter`를 통해 `NSManagedObjectContext.didSaveObjectsNotification`이 발생시키는 이벤트에 대한 publisher를 생성했습니다. `NSManagedObjectContext`는 coreData에서 객체들의 변경 사항을 관리하고 `didSaveObjectsNotification`는 NSManagedObjectContext가 coreData에 변경사항을 영구 저장소에 성공적으로 저장하면 호출됩니다. 결국 코어데이터에 변경사항이 생길경우에 (기록이 생성되거나 기존 기록이 수정될 경우)에 `recordWholeFetch` 함수를 호출해서 변경된 coreData의 기록을 fetch 할 수 있도록 했습니다. 그리고 해당 함수를 onAppear에서 호출합니다. 이 과정을 통해 기록이 변경된 후에만 다시 기록을 fetch하도록 했습니다. 
  
## 🙋🏻 PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

  
## 📷 Key Changes
<!---- 구현 내용 중 애니메이션이나 화면 UI와 관련된 내용이 있을때 넣을 수 있다면 넣어주세요. -->

  
## ✍🏻 To Reviewers
<!---- 팀원들에게 코드리뷰를 할 때 확인해주었으면 하는 내용을 적어주세요. -->
- 도움 주신 ✨@LutherCho✨ 님 압도적 감사‼️‼️🔥