### PR TITLE
Feat: 기록보기 뷰에서 기록 편집 중 뒤로가기 버튼을 누르거나 뒤로가기 제스처 를 할 때의 팝업 메시지와 로직 구현

### DIFF
--- a/Projects/App/Sources/DesignSystem/Common/CustomNavigationBar.swift
+++ b/Projects/App/Sources/DesignSystem/Common/CustomNavigationBar.swift
@@ -11,6 +11,10 @@ import SwiftUI
 struct CustomNavigationBarModifier<C, R>: ViewModifier where C: View, R: View {
     @Environment(\.dismiss) var dismiss
     @GestureState private var dragOffset = CGSize.zero
+    /// Popup 메시지 등장 유무
+    @Binding var availablePopup: Bool
+    /// Popup 메시지 등장 토글
+    @Binding var popupToggle: Bool
     
     /// navigation 제목 뷰
     let centerView: (() -> C)?
@@ -19,10 +23,12 @@ struct CustomNavigationBarModifier<C, R>: ViewModifier where C: View, R: View {
     /// leading 백 버튼 유무, 기본 값 true
     let isShowingBackButton: Bool?
     
-    init(centerView: (() -> C)? = nil, rightView: (() -> R)? = nil, isShowingBackButton: Bool? = true) {
+    init(centerView: (() -> C)? = nil, rightView: (() -> R)? = nil, isShowingBackButton: Bool? = true, availablePopup: Binding<Bool> = .constant(false), popupToggle: Binding<Bool> = .constant(false)) {
         self.centerView = centerView
         self.rightView = rightView
         self.isShowingBackButton = isShowingBackButton
+        self._availablePopup = availablePopup
+        self._popupToggle = popupToggle
     }
     
     func body(content: Content) -> some View {
@@ -31,9 +37,12 @@ struct CustomNavigationBarModifier<C, R>: ViewModifier where C: View, R: View {
                 HStack {
                     if isShowingBackButton ?? true {
                         Button {
-                            dismiss()
-                            
-                            print("dismiss")
+                            if availablePopup == false{
+                                dismiss()
+                                print("dismiss")
+                            } else {
+                                popupToggle = true
+                            }
                         } label: {
                             Image(systemName: "chevron.left")
                         }
@@ -66,7 +75,12 @@ struct CustomNavigationBarModifier<C, R>: ViewModifier where C: View, R: View {
         .gesture(DragGesture().onEnded { value in
             // 여기서 제스처를 인식하고 뒤로 이동하도록 처리해야 합니다.
             if value.translation.width > 100 {
-                dismiss()
+                if availablePopup == false{
+                    dismiss()
+                    print("dismiss")
+                } else {
+                    popupToggle = true
+                }
             }
         })
         .toolbar(.hidden)
@@ -83,6 +97,23 @@ extension View {
             CustomNavigationBarModifier(centerView: centerView,
                                         rightView: rightView,
                                         isShowingBackButton: isShowingBackButton
+                                       )
+        )
+    }
+    
+    func customNavigationBar<C, R>(
+        centerView: @escaping (() -> C),
+        rightView: @escaping (() -> R),
+        isShowingBackButton: Bool? = true,
+        availablePopup: Binding<Bool> = .constant(false),
+        popupToggle: Binding<Bool> = .constant(false)
+    ) -> some View where C: View, R: View {
+        modifier(
+            CustomNavigationBarModifier(centerView: centerView,
+                                        rightView: rightView,
+                                        isShowingBackButton: isShowingBackButton,
+                                        availablePopup: availablePopup,
+                                        popupToggle: popupToggle
                                        )
         )
     }

--- a/Projects/App/Sources/DesignSystem/Form/TextEditor.swift
+++ b/Projects/App/Sources/DesignSystem/Form/TextEditor.swift
@@ -89,6 +89,28 @@ struct CustomTextEditorStyle2: ViewModifier {
     }
 }
 
+struct CustomTextEditorStyle3: ViewModifier {
+    
+    @Binding var text: String
+    
+    func body(content: Content) -> some View {
+        content
+            .font(PretendardFont.bodyMedium)
+            .lineSpacing(7)
+            .padding(.horizontal, 17)
+            .padding(.vertical, 23)
+            .frame(maxWidth: .infinity, minHeight: 214)
+            .background(Color.bright)
+            .clipShape(RoundedRectangle(cornerRadius: 20))
+            .scrollContentBackground(.hidden)
+            .overlay(
+                RoundedRectangle(cornerRadius: 20)
+                    .stroke(Color.sub, lineWidth: 1)
+                    .frame(maxWidth: .infinity, minHeight: 214)
+            )
+    }
+}
+
 extension TextEditor {
     func customStyle(placeholder: String, userInput: Binding<String>) -> some View {
         self.modifier(CustomTextEditorStyle(placeholder: placeholder, text: userInput))
@@ -96,6 +118,10 @@ extension TextEditor {
     
     func customStyle2(userInput: Binding<String>) -> some View {
         self.modifier(CustomTextEditorStyle2(text: userInput))
+    }
+    
+    func customStyle3(userInput: Binding<String>) -> some View {
+        self.modifier(CustomTextEditorStyle3(text: userInput))
     }
 }
 
@@ -105,27 +131,35 @@ struct FormDemo: View {
     @State private var password: String = ""
     @State private var text: String = ""
     @State private var text2: String = ""
+    @State private var text3: String = ""
     private let placeholder: String = "예) 친구를 만나서 영화도 보고 맛있는 것도 먹었어"
     
     var body: some View {
-        VStack {
-            TextField("이름을 입력해주세요", text: $username)
-                .customTF(type: .normal)
-                .padding()
-            
-            TextField("이름을 입력해주세요", text: $password)
-                .customTF(type: .error)
-                .padding()
-            
-            TextEditor(text: $text)
-                .customStyle(placeholder: placeholder, userInput: $text)
-                .frame(height: 200)
-                .padding()
-            
-            TextEditor(text: $text2)
-                .customStyle2(userInput: $text2)
-                .frame(height: 200)
-                .padding()
+        ScrollView {
+            VStack {
+                TextField("이름을 입력해주세요", text: $username)
+                    .customTF(type: .normal)
+                    .padding()
+                
+                TextField("이름을 입력해주세요", text: $password)
+                    .customTF(type: .error)
+                    .padding()
+                
+                TextEditor(text: $text)
+                    .customStyle(placeholder: placeholder, userInput: $text)
+                    .frame(height: 200)
+                    .padding()
+                
+                TextEditor(text: $text2)
+                    .customStyle2(userInput: $text2)
+                    .frame(height: 200)
+                    .padding()
+                
+                TextEditor(text: $text3)
+                    .customStyle3(userInput: $text3)
+                    .frame(height: 200)
+                    .padding()
+            }
         }
     }
 }

--- a/Projects/App/Sources/Presentation/Record/Views/RecordOrganizeView.swift
+++ b/Projects/App/Sources/Presentation/Record/Views/RecordOrganizeView.swift
@@ -119,7 +119,7 @@ struct RecordOrganizeView<viewModel: RecordConditionFetch>: View {
                     
                     ZStack {
                         TextEditor(text: $updateDiary.gptAnswer)
-                            .customStyle2(userInput: $updateDiary.gptAnswer)
+                            .customStyle3(userInput: $updateDiary.gptAnswer)
                             .frame(maxHeight: 214)
                             .disabled(true)
                         

--- a/Projects/App/Sources/Presentation/Record/Views/RecordOrganizeView.swift
+++ b/Projects/App/Sources/Presentation/Record/Views/RecordOrganizeView.swift
@@ -14,7 +14,8 @@ struct RecordOrganizeView<viewModel: RecordConditionFetch>: View {
     @ObservedObject var organizeViewModel: viewModel
     @Binding var isShowingOrganizeView: Bool
     @State var editToggle = false
-    @State var isShowingPopup = false
+    @State var availablePopup = false
+    @State var popupToggle = false
     @State var updateDiary: Diary = .init(date: "", event: "", idea: "", emotions: [], action: "", gptAnswer: "")
     
     var body: some View {
@@ -25,7 +26,7 @@ struct RecordOrganizeView<viewModel: RecordConditionFetch>: View {
                                 .font(PretendardFont.h4Medium)
                         }, rightView: {
                             EmptyView()
-                        }, isShowingBackButton: true)
+                        }, isShowingBackButton: true, availablePopup: $availablePopup, popupToggle: $popupToggle)
         } else {
             organizeView
                 .customNavigationBar(centerView: {
@@ -33,7 +34,10 @@ struct RecordOrganizeView<viewModel: RecordConditionFetch>: View {
                                 .font(PretendardFont.h4Medium)
                         }, rightView: {
                             EmptyView()
-                        }, isShowingBackButton: false)
+                        }, isShowingBackButton: true, availablePopup: $availablePopup, popupToggle: $popupToggle)
+                .popup(isShowing: $popupToggle, type: .doubleButton(leftTitle: "중단하기", rightTitle: "이어쓰기"), title: "편집을 중단할까요?", desc: "편집을 중단하시면 지금까지\n수정한 내용이 모두 삭제돼요.", confirmHandler: { editToggle = false
+                    popupToggle = false
+                    availablePopup = false }, cancelHandler: { popupToggle = false })
         }
     }
     
@@ -69,11 +73,16 @@ struct RecordOrganizeView<viewModel: RecordConditionFetch>: View {
                     Button {
                         bindingText()
                         editToggle = true
-                        isShowingPopup = true
+                        availablePopup = true
                     } label: {
-                        Text("편집")
-                            .font(PretendardFont.h4Bold)
-                            .foregroundColor(Color.symGray3)
+                        if editToggle == false {
+                            Text("편집")
+                                .font(PretendardFont.h4Bold)
+                                .foregroundColor(Color.symGray3)
+                        } else {
+                            Text("")
+                                .disabled(true)
+                        }
                     }
                 }
                 .padding(.bottom, 7)
@@ -160,6 +169,7 @@ struct RecordOrganizeView<viewModel: RecordConditionFetch>: View {
                     Button("수정완료") {
                         organizeViewModel.updateRecord(updateDiary: updateDiary)
                         editToggle = false
+                        availablePopup = false
                     }
                     .buttonStyle(MainButtonStyle(isButtonEnabled: true))
                     .padding(.horizontal, 20)

--- a/Projects/App/Sources/Presentation/Record/Views/RecordOrganizeView.swift
+++ b/Projects/App/Sources/Presentation/Record/Views/RecordOrganizeView.swift
@@ -14,9 +14,30 @@ struct RecordOrganizeView<viewModel: RecordConditionFetch>: View {
     @ObservedObject var organizeViewModel: viewModel
     @Binding var isShowingOrganizeView: Bool
     @State var editToggle = false
+    @State var isShowingPopup = false
     @State var updateDiary: Diary = .init(date: "", event: "", idea: "", emotions: [], action: "", gptAnswer: "")
     
     var body: some View {
+        if editToggle == false {
+            organizeView
+                .customNavigationBar(centerView: {
+                            Text("\(organizeViewModel.recordDiary.date) 일기")
+                                .font(PretendardFont.h4Medium)
+                        }, rightView: {
+                            EmptyView()
+                        }, isShowingBackButton: true)
+        } else {
+            organizeView
+                .customNavigationBar(centerView: {
+                            Text("\(organizeViewModel.recordDiary.date) 일기")
+                                .font(PretendardFont.h4Medium)
+                        }, rightView: {
+                            EmptyView()
+                        }, isShowingBackButton: false)
+        }
+    }
+    
+    var organizeView: some View {
         ScrollView(showsIndicators: false) {
             VStack(alignment: .leading) {
                 Spacer(minLength: 33)
@@ -48,6 +69,7 @@ struct RecordOrganizeView<viewModel: RecordConditionFetch>: View {
                     Button {
                         bindingText()
                         editToggle = true
+                        isShowingPopup = true
                     } label: {
                         Text("편집")
                             .font(PretendardFont.h4Bold)
@@ -145,12 +167,6 @@ struct RecordOrganizeView<viewModel: RecordConditionFetch>: View {
             }
         }
         .dismissKeyboardOnTap()
-        .customNavigationBar(centerView: {
-            Text("\(organizeViewModel.recordDiary.date) 일기")
-                .font(PretendardFont.h4Medium)
-        }, rightView: {
-            EmptyView()
-        }, isShowingBackButton: true)
     }
     
     let screenSize = UIScreen.main.bounds.size.width


### PR DESCRIPTION
## ✨ Feat: 기록보기 뷰에서 기록 편집 중 뒤로가기 버튼을 누르거나 뒤로가기 제스처를 할 때의 팝업 메시지와 로직 구현 #144
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 기록보기 뷰에서 편집 중에 뒤로가기를 시도하면 경고 팝업 메시지가 등장하게 했습니다.
- 뒤로가기 버튼을 눌렀을 때 팝업 메시지가 나타나게 하는 로직을 추가하기 위해서 **CustomNavigationBar**를 수정했습니다.
- 팝업메시지에서 중단하기를 누르면 처음의 기록보기 뷰의 상태로 돌아갑니다.
- 이어쓰기를 누르면 편집 중인 상태 그대로 돌아갑니다.
- 제스처로 뒤로가기를 할 때도 작동하도록 했습니다.
- 편집 중인 동안은 편집버튼이 사라지게 했습니다.

 ++ 시미의 공감 부분은 수정하지 못하게 되어 있지만 편집 버튼을 누르면 똑같이 글자 수 제한이 나타나서 TextEditorStyle을 하나 더 만들어서 없앴습니다.
<!---- Resolves: #(Isuue Number) 이슈 넘버링 해주세요! -->
  
## 🙋🏻 PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

  
## 📷 Key Changes
<!---- 구현 내용 중 애니메이션이나 화면 UI와 관련된 내용이 있을때 넣을 수 있다면 넣어주세요. -->
https://github.com/Good-MoGong/SYM/assets/66257281/fe55f2a7-da12-46c5-b53a-cfd8d95d5425
  
## ✍🏻 To Reviewers
<!---- 팀원들에게 코드리뷰를 할 때 확인해주었으면 하는 내용을 적어주세요. -->
